### PR TITLE
Add content type param to search for entries

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,7 +44,7 @@ class MyHomePage extends StatelessWidget {
               json as Map<String, dynamic>,
               (json) => ExampleDataModel.fromJson(json as Map<String, dynamic>),
             ),
-            modelName: 'example',
+            contentType: 'example',
           ),
           builder: (context, snapshot) {
             if (snapshot.hasError) {

--- a/lib/src/core/data_models/contentful_delivery_data_model.dart
+++ b/lib/src/core/data_models/contentful_delivery_data_model.dart
@@ -1,72 +1,38 @@
 import 'package:contentful_flutter/contentful_flutter.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-/// [ContentfulDeliveryDataModel] is the base model for the contentful delivery
-/// API returned from the API.
-/// It contains the [sys] information, the [total] number of items, the [skip]
-/// and [limit] values. It also contains the [items] and [includes] that are
-/// returned from the API. The [items] are the entries that are returned from
-/// the API.
-/// The [includes] are the assets and linked entries that are returned from the
-/// API.
+part 'contentful_delivery_data_model.freezed.dart';
+part 'contentful_delivery_data_model.g.dart';
 
-class ContentfulDeliveryDataModel<T> {
-  ///
-  ContentfulDeliveryDataModel({
-    required this.total,
-    required this.items,
-    this.sys,
-    this.skip,
-    this.limit,
-    this.includes,
-  });
+@Freezed(genericArgumentFactories: true)
 
-  ///
+/// [ContentfulDeliveryDataModel] is the base model for the contentful delivery API
+/// returned from the API.
+/// It contains the [sys] information, the [total] number of items, the [skip] and [limit] values.
+/// It also contains the [items] and [includes] that are returned from the API.
+/// The [items] are the entries that are returned from the API.
+/// The [includes] are the assets and linked entries that are returned from the API.
+class ContentfulDeliveryDataModel<T> with _$ContentfulDeliveryDataModel<T> {
+  /// [ContentfulDeliveryDataModel] is the base model for the contentful delivery API
+  /// returned from the API.
+  /// It contains the [sys] information, the [total] number of items, the [skip] and [limit] values.
+  /// It also contains the [items] and [includes] that are returned from the API.
+  /// The [items] are the entries that are returned from the API.
+  /// The [includes] are the assets and linked entries that are returned from the API.
+  factory ContentfulDeliveryDataModel({
+    @Default(0) int total,
+    Sys? sys,
+    int? skip,
+    int? limit,
+    @Default([]) List<T> items,
+    Includes? includes,
+  }) = _ContentfulDeliveryDataModel<T>;
+
+  /// [ContentfulDeliveryDataModel.fromJson] is used to convert the json that is received from the
+  /// Contentful API into a [ContentfulDeliveryDataModel] object.
   factory ContentfulDeliveryDataModel.fromJson(
     Map<String, dynamic> json,
-    T Function(Object?) fromJsonT, {
-    required String modelName,
-  }) {
-    final items = <T>[];
-
-    for (final item in json['items'] as List) {
-      try {
-        // Getting the modelName from the sys to check if it's the right model
-        final modelNameId = item['sys']['contentType']['sys']['id'] as String;
-        if (modelName == modelNameId) {
-          items.add(fromJsonT(item));
-        }
-      } catch (e) {
-        debugPrint('Parsing an item has failed \n$e');
-      }
-    }
-
-    return ContentfulDeliveryDataModel(
-      total: json['total'] as int? ?? 0,
-      sys: Sys.fromJson(json['sys'] as Map<String, dynamic>),
-      skip: json['skip'] as int?,
-      limit: json['limit'] as int?,
-      includes: Includes.fromJson(json['includes'] as Map<String, dynamic>),
-      items: items,
-    );
-  }
-
-  /// total number of entries
-  final int total;
-
-  /// [sys] contains Contentful system info
-  final Sys? sys;
-
-  /// [skip] is the number of skipped entries
-  final int? skip;
-
-  /// [limit] is the limit number of entries
-  final int? limit;
-
-  /// [includes] is the list of assets
-  final Includes? includes;
-
-  /// [items] is the list of returned items depending
-  /// on the modelName given in the fromJson method
-  final List<T> items;
+    T Function(Object?) fromJsonT,
+  ) =>
+      _$ContentfulDeliveryDataModelFromJson(json, fromJsonT);
 }

--- a/lib/src/core/repositories/contentful_delivery_api_repository.dart
+++ b/lib/src/core/repositories/contentful_delivery_api_repository.dart
@@ -18,11 +18,11 @@ class ContentfulDeliveryAPIRepository {
   /// Parses the language to utf8. Throws Exception on error.
   Future<ContentfulDeliveryDataModel<T>> getEntries<T>({
     required T Function(Object?) fromJsonT,
-    required String modelName,
+    required String contentType,
   }) async {
     final url = '$_baseUrl/spaces/${_client.spaceId}/environments'
         '/${_client.environmentId}/entries?access_token=${_client.accessToken}'
-        '&locale=${_client.locale.languageCode}';
+        '&locale=${_client.locale.languageCode}&content_type=$contentType';
     final response = await http.get(Uri.parse(url));
     if (response.statusCode == 200) {
       final body = utf8.decode(response.bodyBytes);
@@ -31,7 +31,6 @@ class ContentfulDeliveryAPIRepository {
       final result = ContentfulDeliveryDataModel.fromJson(
         jsonBody,
         fromJsonT,
-        modelName: modelName,
       );
       return result;
     } else {
@@ -69,7 +68,10 @@ class ContentfulDeliveryAPIRepository {
     if ((sys.type?.isLink ?? false) &&
         (sys.linkType?.isAsset ?? false) &&
         includes != null) {
-      return getAssetUrlFrom(assetId: sys.idOrNull, includes: includes);
+      return getAssetUrlFrom(
+        assetId: sys.idOrNull,
+        includes: includes,
+      );
     }
     return null;
   }


### PR DESCRIPTION
## Status

**READY**

## Description

- Add contentType param to getEntries method to filter only needed entries.
- Rollback ContentfulDeliveryDataModel.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
